### PR TITLE
- Fix: make it run properly when contianer's up

### DIFF
--- a/dockerfiles/Dockerfile
+++ b/dockerfiles/Dockerfile
@@ -17,6 +17,12 @@ RUN mkdir /data
 RUN chmod 0775 /usr/local/bin/lotus-exporter-farcaster.py
 RUN chmod 0775 /usr/local/bin/docker_run_script.sh
 
+# Make a link from python3.9 to python3
+RUN ln -sv /usr/local/bin/python3.9 /usr/bin/python3
+
+# Add the lib of python
+RUN python3 -m pip install aiohttp toml py-multibase
+
 # Run the container on an unprivileged user XXX not implemented yet // need rights to store files to prometheus folder
 #RUN useradd -r -u 424242 -U farcaster
 #USER farcaster


### PR DESCRIPTION
Recently, I've using docker with lotus-farcaster, and then i found it would not run properly when the container started.
1. The path of python do not correct, so, I make a soft link to fix it.
2. The container do not install the python libs while required, therefore, I add an installation command.