### PR TITLE
Fix a crash when the Event Log entries array is empty

### DIFF
--- a/lotus-exporter-farcaster/lotus-exporter-farcaster.py
+++ b/lotus-exporter-farcaster/lotus-exporter-farcaster.py
@@ -1161,16 +1161,19 @@ def collect(daemon, miner, markets, metrics, addresses_config):
             deal_weight = int(detail["result"]["DealWeight"])
             qa_power = daemon.qa_power_for_weight(size, duration, deal_weight, verified_weight)
 
-        creation_date = detail["result"]["Log"][0]["Timestamp"]
+        creation_date = ""
         packed_date = ""
         finalized_date = ""
+
+        if detail["result"]["Log"]:
+            creation_date = detail["result"]["Log"][0]["Timestamp"]
 
         for log in range(len(detail["result"]["Log"])):
             if detail["result"]["Log"][log]["Kind"] == "event;sealing.SectorPacked":
                 packed_date = detail["result"]["Log"][log]["Timestamp"]
             if detail["result"]["Log"][log]["Kind"] == "event;sealing.SectorFinalized":
                 finalized_date = detail["result"]["Log"][log]["Timestamp"]
-        if detail["result"]["Log"][0]["Kind"] == "event;sealing.SectorStartCC":
+        if detail["result"]["Log"] and detail["result"]["Log"][0]["Kind"] == "event;sealing.SectorStartCC":
             pledged = 1
         else:
             pledged = 0


### PR DESCRIPTION
If the Event Log entry of ./lotus-miner sectors status --log <sector#> is
emptly, lotus-exporter-farcaster.py will crash with Index out of range.
This fix protects the array access if the array is empty.